### PR TITLE
feat: login and welcome page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "firebase": "^11.9.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
@@ -4471,6 +4472,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "firebase": "^11.9.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {

--- a/src/components/CopyID.tsx
+++ b/src/components/CopyID.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+
+const CopyID = ({ uniqueID }: { uniqueID: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(uniqueID);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500); // 복사 완료 메시지 1.5초 후 사라짐
+    } catch (err) {
+      console.error("복사 실패", err);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center mb-4">
+        <p className="text-base text-gray-600 mb-1">내 아이디</p>
+        <div className="flex items-center space-x-2">
+            <input
+            type="text"
+            value={uniqueID}
+            readOnly
+            className="w-72 text-center px-4 py-2 border border-gray-300 rounded-md bg-gray-50 text-gray-700 shadow-sm"
+            />
+            <button
+            onClick={handleCopy}
+            className="px-3 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-md text-sm transition"
+            >
+            📋 복사
+            </button>
+        </div>
+        {copied && (
+            <p className="mt-2 text-sm text-green-600">아이디가 복사되었습니다</p>
+        )}
+    </div>
+  );
+};
+
+export default CopyID;

--- a/src/pages/LoginHome.tsx
+++ b/src/pages/LoginHome.tsx
@@ -1,0 +1,71 @@
+// 아이디 등록 홈 페이지
+
+import { auth, provider, db } from "../firebase/firebase";
+import { signInWithPopup } from "firebase/auth";
+import { doc, setDoc, getDoc } from "firebase/firestore";
+import { useNavigate } from "react-router-dom";
+import { FcGoogle } from "react-icons/fc"
+
+const LoginHome = () => {
+  const navigate = useNavigate();
+
+  const handleGoogleLogin = async() =>{
+    try {
+      const result = await signInWithPopup(auth, provider); //로그인
+      const user = result.user; //사용자 정보 저장
+
+      if(user){
+        const userRef = doc(db,"user", user.uid);
+        const userSnap = await getDoc(userRef);
+
+        if(!userSnap.exists()){
+          //문서 없을 시 새로 저장(신규 가입자)
+          const randomId = Math.random().toString(36).substring(2, 10) //8자리 고유번호
+          await setDoc(userRef,{
+            uid: user.uid,
+            email: user.email,
+            displayName: user.displayName,
+            uniqueID: randomId,
+            photoURL: user.photoURL,
+          });
+
+          //최초 가입자 -> welcome 페이지
+          localStorage.setItem("uniqueID", randomId);
+          navigate("/Login", {state:{uniqueID: randomId}});
+
+        } else {
+          //기존 사용자는 바로 캘린더로
+          const uniqueID = userSnap.data().uniqueID;
+          localStorage.setItem("uniqueID", uniqueID);
+          navigate("/Calendar");          
+        }
+      }
+    } catch (error){
+        console.error("로그인 오류", error);
+        alert("로그인 실패");
+        navigate("/Notfound");
+    }
+  };
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[500px] bg-white">
+      {/* 제목과 소개 문장 영역 */}
+      <div className="mb-24 text-center">
+        <h1 className="text-5xl font-bold text-gray-800 mb-2">25H</h1>
+        <p className="text-lg text-gray-600 mb-6">25분 뽀모도로 집중하기</p>
+      </div>
+
+      {/* 로그인 버튼 영역 */}
+      <button
+        onClick={handleGoogleLogin}
+        className="flex items-center justify-center gap-2 w-64 min-w-[256px] min-h-[48px] py-2 px-4 border border-gray-300 rounded-[10px] bg-[#FFFFFF]"
+      >
+        <FcGoogle size={20} />
+        <span className="text-base text-gray-700 font-normal">구글 로그인</span>
+      </button>
+
+    </div>
+    
+  );
+};
+
+export default LoginHome;

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -1,0 +1,40 @@
+//신규 가입자 환영 페이지로 변경 예정
+
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import CopyID from "../components/CopyID";
+
+
+const Welcome = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const uniqueID = location.state?.uniqueID || localStorage.getItem("uniqueID");
+
+  useEffect(()=>{
+    if(!uniqueID){
+      navigate("/NotFound"); //ID없을 시 오류 페이지로 이동
+    }
+  },[uniqueID, navigate]);
+
+  const handleStart = () =>{
+    navigate("/Calendar");
+  };
+  
+  return (
+    <div  className="flex flex-col items-center justify-center min-h-screen px-4 bg-white">
+      <h1 className="text-3xl font-bold text-gray-800 mb-6">가입을 환영합니다!</h1>
+      
+      <CopyID uniqueID={uniqueID||""}/>
+
+      <ul className="mb-6 text-sm text-gray-500 space-y-1">
+        <li>📢 아이디는 최초 가입 시 부여되며, 수정할 수 없습니다. </li>
+        <li>📢 이후 친구목록에서 내 아이디를 확인할 수 있습니다.</li>
+      </ul>
+
+      <button onClick={handleStart} className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-lg shadow transition">시작하기</button>
+    </div>
+  );
+
+};
+
+export default Welcome;


### PR DESCRIPTION
1. Home에 테스트코드가 있는 것 같아 새로운 파일 LoginHome 생성
2. 로그인 기능은 홈화면에 있기 때문에 LoginHome으로 이동
3. 아이디 복사 컴포넌트 추가
4. 로그인 이후 환영 페이지 추가(figma 2번째 페이지에 해당)
5. "react-icons/fc" 설치 (구글 아이콘 목적)